### PR TITLE
Change oc env command for newer versions of OpenShift

### DIFF
--- a/openshift/demo-auth.sh
+++ b/openshift/demo-auth.sh
@@ -69,7 +69,7 @@ admin_pwd=$(oc logs -c kdc $server_pod | head -n 1 | sed 's/.*Your\ KDC\ passwor
 
 app_pod=$(oc get pods -l app=client -o name)
 
-principal=$(oc env $app_pod --list | grep OPTIONS | grep -o "[a-z]*\@[A-Z\.]*")
+principal=$(oc rsh $app_pod env | grep OPTIONS | grep -o "[a-z]*\@[A-Z\.]*")
 realm=$(echo $principal | sed 's/[a-z]*\@//')
 
 # create principal


### PR DESCRIPTION
It looks like the OpenShift CLI has moved since the demo_auth.sh script was written, this change replaces the command with "oc rsh <pod> env"